### PR TITLE
Drop six dependency to remove python 2 support

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,14 +1,20 @@
-As of 16 July 2016, the master branch has preliminary support for Python 3. It makes use of six to support both Python 2.7 and 3+. 
-
-**Requirements**
-numpy, scipy, matplotlib
-pyproj
-pytables
-six
-
-
 Gridded Flash Products using lmatools
 =====================================
+
+Requirements
+------------
+- python 3.6+ (no support for Python 2)
+- numpy
+- scipy
+- pyproj
+
+For flash sorting and plotting:
+
+- scikit-learn
+- pytables
+- matplotlib
+
+
 
 Usage
 -----
@@ -25,7 +31,11 @@ Configuration
 
 VHF sources are grouped into flashes by first filtering out noise sources by using the reduced chi-squared value and number of contributing stations for each VHF source. Chi-squared of less than 5.0 is typical; 1.0 is one threshold in wide use. For all but the worst-performing networks, a minimum of six stations should be used; where available, seven or more will give the most noise-free results. These values should be determined by examining the source data for time periods of interest on a case-by-case basis. This step is especially important for networks with frequent station drop-outs, where the network is asymmetric, or where the network has poor sensitivity.
 
-Sources are grouped into flashes using space and time criteria. These default to 3 km spatial and 0.15 second temporal thresholds, with a maximum duration of 3 s. At the moment, the McCaul et al. (2009, Weather and Forecasting) flash sorting algorithm is the only one integrated into this codebase. (Prototype sorting using the clustering features in Python's scikits-learn is now in the repository in lmatools/flashsort/examples/, but is not yet integrated.)
+Sources are grouped into flashes using space and time criteria. These default to 3 km spatial and 0.15 second temporal thresholds, with a maximum duration of 3 s. The only fully integrated algorithm in this codebase uses the DBSCAN clustering features in Python's scikit-learn. The flash sorting process is described in Fuchs et al. (2016),
+
+> Fuchs, B. R., E. C. Bruning, S. A. Rutledge, L. D. Carey, P. R. Krehbiel, and W. Rison, 2016: Climatological analyses of LMA data with an open-source lightning flash-clustering algorithm. J. Geophys. Res. Atmos., 121, 8625–8648, [doi:10.1002/2015JD024663](https://dx.doi.org/10.1002/2015JD024663).
+
+There is historical support for the McCaul et al. (2009, Weather and Forecasting) flash sorting algorithm, but it is not included here. The code architecture supports the addition of other algorithms.
 
 Flashes are turned into gridded products by grabbing a flash, including associated VHF source points, performing filtering to select for certain kinds of flashes, doing necessary coordinate transformations, and then determining how each flash contributes to a gridded product field that has some meaning of interest. A requirement is levied on the minimum number of sources per flash, usually ten. The processing is implemented as a coroutine-style pipeline where flashes are pushed down the pipe before landing on a grid.
 

--- a/examples/DC3_plots.py
+++ b/examples/DC3_plots.py
@@ -10,7 +10,6 @@ import subprocess
 from lmatools.grid.make_grids import grid_h5flashfiles, dlonlat_at_grid_center, write_cf_netcdf_latlon
 from lmatools.flashsort.autosort import autorun
 from lmatools.vis.multiples_nc import make_plot
-from six.moves import map
 
 # Meant to be run on a just one day's worth of processed data
 

--- a/examples/flash_sort_and_grid.py
+++ b/examples/flash_sort_and_grid.py
@@ -22,7 +22,6 @@ from lmatools.flashsort.gen_sklearn import DBSCANFlashSorter
 
 from lmatools.grid.make_grids import grid_h5flashfiles, dlonlat_at_grid_center, write_cf_netcdf_latlon, write_cf_netcdf_3d_latlon
 from lmatools.vis.multiples_nc import make_plot, make_plot_3d, read_file_3d
-from six.moves import map
 
 
 def tfromfile(name):

--- a/examples/flashsort/varyparams/examine_big_run.py
+++ b/examples/flashsort/varyparams/examine_big_run.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import os
 import glob
 import tables as T
-from six.moves import zip
 
 base_out_dir = '/Users/ebruning/out/flash_sort/'
 params_filename = 'input_params.py'

--- a/lmatools/NLDN.py
+++ b/lmatools/NLDN.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from datetime import datetime
 import numpy as np
 from numpy.lib.recfunctions import drop_fields, append_fields
-from six.moves import zip
 
 class NLDNdataFile(object):
     

--- a/lmatools/flash_stats.py
+++ b/lmatools/flash_stats.py
@@ -9,8 +9,6 @@ from lmatools.io.LMA_h5_file import read_flashes
 from lmatools.stream.subset import coroutine, Branchpoint
 
 from lmatools.flashsort.flash_stats import hull_volume
-from six.moves import range
-from six.moves import zip
 
 def gen_flash_events(events, flashes):
     """ Given events and flashes tables, generate

--- a/lmatools/flashsort/autosort/autorun_mflash.py
+++ b/lmatools/flashsort/autosort/autorun_mflash.py
@@ -12,10 +12,8 @@ from lmatools.flashsort.flash_stats import calculate_flash_stats, Flash, FlashMe
 from lmatools.io.LMAarrayFile import cat_LMA, LMAdataFile
 
 from .mflash import write_header
-from six.moves import zip
 
 LOG_BASEFILENAME = datetime.datetime.now().strftime('Flash-autosort.log')
-
 
 
 def logger_setup(logpath):

--- a/lmatools/flashsort/autosort/autorun_sklearn.py
+++ b/lmatools/flashsort/autosort/autorun_sklearn.py
@@ -12,9 +12,6 @@ from lmatools.io.LMAarrayFile import LMAdataFile
 from lmatools.coordinateSystems import GeographicSystem
 
 from lmatools.flashsort.flash_stats import calculate_flash_stats, Flash, FlashMetadata
-from six.moves import range
-from six.moves import zip
-
 
 
 @coroutine

--- a/lmatools/flashsort/flash_stats.py
+++ b/lmatools/flashsort/flash_stats.py
@@ -7,7 +7,6 @@ import re
 from scipy.spatial import Delaunay, ConvexHull
 from scipy.special import factorial
 from scipy.spatial.qhull import QhullError
-from six.moves import range
 
 from lmatools.lasso import empirical_charge_density as cd
 

--- a/lmatools/flashsort/gen_sklearn.py
+++ b/lmatools/flashsort/gen_sklearn.py
@@ -10,10 +10,8 @@ from sklearn.cluster import DBSCAN
 from lmatools.coordinateSystems import GeographicSystem
 
 from lmatools.flashsort.flash_stats import calculate_flash_stats, Flash
-from six.moves import range
-from six.moves import zip
-from six import next
- 
+
+
 def gen_stream(vec, IDs): #<1>
     for v, vi in zip(vec, IDs):
         yield (v, vi)

--- a/lmatools/fmsc/FMSC.py
+++ b/lmatools/fmsc/FMSC.py
@@ -13,9 +13,8 @@ from scipy.spatial import cKDTree as KDTree
 from scipy import sparse
 
 from .InterpolationMatrix import interpolation_matrix
-from six.moves import range
-from six.moves import zip
-    
+
+
 def initial_weights(data, k, min_dist=None):
     """ Calculate a matrix of weights for the k nearest points.
     

--- a/lmatools/fmsc/InterpolationMatrix.py
+++ b/lmatools/fmsc/InterpolationMatrix.py
@@ -4,7 +4,7 @@ import itertools
 
 import numpy as np
 from scipy import sparse
-from six.moves import range
+
 
 def interpolation_matrix(A_in, alpha, ignore_negative=True, should_dilute=True, dilutThresh=0.1, dilutLimit=1.0, is_laplac=True):
     """ Create an interpolation matrix according to the given matrix A and a threshold alpha.

--- a/lmatools/grid/AWIPS_tools.py
+++ b/lmatools/grid/AWIPS_tools.py
@@ -4,7 +4,6 @@ import datetime
 import scipy.io.netcdf as nc
 import glob
 from .make_grids import grid_h5flashfiles
-from six.moves import range
 
 def write_AWIPS_netcdf_grid(outfile, t_start, t, xloc, yloc, lon_for_x, lat_for_y, 
                 ctr_lat, ctr_lon, grid, grid_var_name, grid_description, format='i',

--- a/lmatools/grid/cf_netcdf.py
+++ b/lmatools/grid/cf_netcdf.py
@@ -3,10 +3,6 @@ from __future__ import print_function
 
 from functools import partial
 
-import numpy as np
-
-from six.moves import range
-
 try:
     from netCDF4 import Dataset as NetCDFFile
 except ImportError:

--- a/lmatools/grid/density_to_files.py
+++ b/lmatools/grid/density_to_files.py
@@ -5,7 +5,6 @@ import gc
 import numpy as np
 from lmatools.stream.subset import coroutine
 from lmatools.density_tools import unique_vectors
-from six.moves import zip
 
 import logging
 log = logging.getLogger(__name__)

--- a/lmatools/grid/grid_collection.py
+++ b/lmatools/grid/grid_collection.py
@@ -12,8 +12,7 @@ except ImportError:
     from scipy.io.netcdf import NetCDFFile
 
 from lmatools.vis.multiples_nc import centers_to_edges
-from six.moves import range
-        
+
 class LMAgridFileCollection(object):
     def __init__(self, filenames, grid_name, 
                  x_name='x', y_name='y', t_name='time'):

--- a/lmatools/grid/make_grids.py
+++ b/lmatools/grid/make_grids.py
@@ -20,7 +20,6 @@ from lmatools.stream.subset import broadcast
 from lmatools.io.LMA_h5_file import read_flashes, to_seconds
 
 from lmatools.coordinateSystems import MapProjection, GeographicSystem
-from six.moves import range
 
 from .cf_netcdf import (write_cf_netcdf, write_cf_netcdf_3d,
     write_cf_netcdf_latlon, write_cf_netcdf_3d_latlon,

--- a/lmatools/io/LMA_h5_write.py
+++ b/lmatools/io/LMA_h5_write.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import tables as T
 import numpy as np
 import logging
-from six.moves import range
 
 # Write this many flashes at a time
 flash_chunk = 100 # was 10000 rows

--- a/lmatools/io/LMAarrayFile.py
+++ b/lmatools/io/LMAarrayFile.py
@@ -4,9 +4,6 @@ import os, re #, gzip
 import numpy as np
 import logging
 import subprocess
-from six.moves import map
-from six.moves import range
-from six.moves import zip
 
 logger = logging.getLogger('FlashAutorunLogger')
 

--- a/lmatools/lasso/cell_lasso_util.py
+++ b/lmatools/lasso/cell_lasso_util.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 import logging, json, operator
 
 import numpy as np
-from six.moves import zip
 
 from lmatools.io.LMA_h5_file import parse_lma_h5_filename
 

--- a/lmatools/lasso/energy_stats.py
+++ b/lmatools/lasso/energy_stats.py
@@ -20,8 +20,6 @@ from matplotlib.ticker import MultipleLocator
 from lmatools.flash_stats import raw_moments, raw_moments_for_parameter, central_moments_from_raw, events_flashes_receiver
 from lmatools.grid.make_grids import time_edges, seconds_since_start_of_day
 import matplotlib.pyplot as plt
-import six
-from six.moves import range
 
 def summary_stat_line(start_t, end_t, moments):
     """ Moments should be a tuple of number, mean, variance, skewness, kurtosis """
@@ -355,7 +353,7 @@ class TimeSeriesPolygonLassoFilter(object):
         good = np.zeros(a.shape, dtype=bool)
         
         t = a[self.time_key]
-        for (t0, t1), poly_target in six.iteritems(self.poly_lookup):
+        for (t0, t1), poly_target in self.poly_lookup.items():
             # make sure this is only one-side inclusive to eliminate double-counting
             in_time = (t >= t0) & (t < t1)
             reduced = a[in_time]

--- a/lmatools/lasso/length_stats.py
+++ b/lmatools/lasso/length_stats.py
@@ -31,8 +31,6 @@ from lmatools.grid.make_grids import time_edges, seconds_since_start_of_day
 
 from stormdrain.pipeline import coroutine, Branchpoint
 from stormdrain.support.matplotlib.formatters import SecDayFormatter
-from six.moves import range
-from six.moves import zip
 
 def gen_fractal_length_for_flashes(events, flashes, D, b_s, alt_bins):
     """ Given events and flashes, calculate the fractal length

--- a/lmatools/live/liveLMA.py
+++ b/lmatools/live/liveLMA.py
@@ -5,7 +5,6 @@ import numpy as np
 from collections import deque
 
 import threading
-import six
 
 # 
 # # Header data is packed in a structure:
@@ -175,7 +174,7 @@ class LiveLMAController(object):
         # See time handling in archive_to_LiveLMA for examples
         data['t'] = sources['t'].astype('f8')+header['header_second'].astype('f8')
         
-        for k, v in six.iteritems(self.dtype_mapping):
+        for k, v in self.dtype_mapping.items():
             data[v] = sources[k]
             
         for view in self.views:

--- a/lmatools/stream/subset.py
+++ b/lmatools/stream/subset.py
@@ -24,7 +24,6 @@ a few more del statements might be needed.
 from __future__ import absolute_import
 from __future__ import print_function
 import numpy as np
-from six.moves import zip
 
 
 def coroutine(func):

--- a/lmatools/test/test_gen_autorun_DBSCAN.py
+++ b/lmatools/test/test_gen_autorun_DBSCAN.py
@@ -11,7 +11,6 @@ from lmatools.flashsort.gen_sklearn import DBSCANFlashSorter
 
 from lmatools.grid.make_grids import grid_h5flashfiles, dlonlat_at_grid_center, write_cf_netcdf_latlon, write_cf_netcdf_3d_latlon, write_cf_netcdf, write_cf_netcdf_3d
 from lmatools.vis.multiples_nc import make_plot, make_plot_3d, read_file_3d
-from six.moves import map
 
 
 def get_sample_data_list():

--- a/lmatools/test/test_sklearn.py
+++ b/lmatools/test/test_sklearn.py
@@ -25,7 +25,7 @@ def tfromfile(name):
     parts = name.split('_')
     y, m, d = list(map(int, (parts[-3][0:2], parts[-3][2:4], parts[-3][4:6])))
     H, M, S = list(map(int, (parts[-2][0:2], parts[-2][2:4], parts[-2][4:6])))
-    return y+2000,m,d,H,M,S    
+    return y+2000,m,d,H,M,S
 
 def test_sort_and_grid_and_plot(outpath):
     """ Given an output path, run sample data included in lmatools through flash sorting and gridding"""
@@ -44,7 +44,7 @@ def test_sort_and_grid_and_plot(outpath):
     h5_dir = os.path.join(base_sort_dir, 'h5_files')
     grid_dir = os.path.join(base_sort_dir, 'grid_files')
     plot_dir = os.path.join(base_sort_dir, 'plots')
-    
+
     y,m,d,H,M,S = tfromfile(files[0])
     date = datetime(y,m,d, H,M,S)
 
@@ -55,16 +55,16 @@ def test_sort_and_grid_and_plot(outpath):
         subprocess.call(['chmod', 'a+w', base_out_dir, h5_dir+'/20%s' %(date.strftime('%y/%b')), h5_dir+'/20%s' %(date.strftime('%y'))])
 
     tag = ''
-    outdir = os.path.join(base_out_dir, tag) 
+    outdir = os.path.join(base_out_dir, tag)
     info = open(os.path.join(outdir, 'input_params.py'), 'w')
     info.write(str(params))
     info.close()
-    
+
     run_files_with_params(files, outdir, params, cluster, retain_ascii_output=False, cleanup_tmp=True)
     # Figure out which HDF5 files were created
     h5_filenames = glob.glob(h5_dir+'/20%s/LYLOUT*.dat.flash.h5' %(date.strftime('%y/%b/%d')))
     h5_filenames.sort()
-    
+
     # Create NetCDF gridded data
     frame_interval=60.0*2 # seconds
     dx_km=3.0e3 # meters
@@ -73,20 +73,20 @@ def test_sort_and_grid_and_plot(outpath):
     y_bnd_km = (-200e3, 200e3)
 
     # There are similar functions in lmatools to grid on a regular x,y grid in some map projection.
-    dx, dy, x_bnd, y_bnd = dlonlat_at_grid_center(ctr_lat, ctr_lon, 
+    dx, dy, x_bnd, y_bnd = dlonlat_at_grid_center(ctr_lat, ctr_lon,
                                 dx=dx_km, dy=dy_km,
                                 x_bnd = x_bnd_km, y_bnd = y_bnd_km )
     # print("dx, dy = {0}, {1} deg".format(dx,dy))
     # print("lon_range = {0} deg".format(x_bnd))
     # print("lat_range = {0} deg".format(y_bnd))
-    
+
     for f in h5_filenames:
         y,m,d,H,M,S = tfromfile(f)
         # print y,m,d,H,M,S
         start_time = datetime(y,m,d, H,M,S)
         end_time   = start_time + timedelta(0,600)
         # print start_time, end_time
-    
+
         outpath = grid_dir+'/20%s' %(date.strftime('%y/%b/%d'))
         if os.path.exists(outpath) == False:
             os.makedirs(outpath)
@@ -94,14 +94,18 @@ def test_sort_and_grid_and_plot(outpath):
         grid_h5flashfiles(h5_filenames, start_time, end_time, frame_interval=frame_interval, proj_name='latlong',
                     dx=dx, dy=dy, x_bnd=x_bnd, y_bnd=y_bnd, ctr_lon=ctr_lon, ctr_lat=ctr_lat, outpath = outpath,
                     output_writer = write_cf_netcdf_latlon, output_filename_prefix=center_ID, spatial_scale_factor=1.0,
-                    energy_grids=True)
-        
+                    energy_grids=True, do_3d=False)
+
     # Create plots
     n_cols=2
     mapping = { 'source':'lma_source',
                 'flash_extent':'flash_extent',
                 'flash_init':'flash_initiation',
-                'footprint':'flash_footprint'}
+                'footprint':'flash_footprint',
+                'flashsize_std':'flashsize_std',
+                'specific_energy':'specific_energy',
+                'total_energy':'total_energy',
+              }
 
     #nc_names = glob.glob('/home/ebruning/Mar18-19/grids/*.nc')
     nc_names = glob.glob(grid_dir+'/20%s/*.nc' %(date.strftime('%y/%b/%d')))
@@ -116,10 +120,10 @@ def test_sort_and_grid_and_plot(outpath):
         var = mapping[gridtype]
         # print f
         make_plot(f, var, n_cols=n_cols, x_name='longitude', y_name='latitude', outpath = outpath)
-    
 
 
-if __name__ == '__main__':    
+
+if __name__ == '__main__':
     outpath = sys.argv[1]
     outpath = os.path.abspath(outpath)
     test_sort_and_grid_and_plot(outpath)

--- a/lmatools/test/test_sklearn.py
+++ b/lmatools/test/test_sklearn.py
@@ -11,7 +11,6 @@ from lmatools.flashsort.autosort.autorun_sklearn import cluster
 
 from lmatools.grid.make_grids import grid_h5flashfiles, dlonlat_at_grid_center, write_cf_netcdf_latlon
 from lmatools.vis.multiples_nc import make_plot
-from six.moves import map
 
 
 def get_sample_data_list():

--- a/lmatools/vis/multiples_nc.py
+++ b/lmatools/vis/multiples_nc.py
@@ -23,7 +23,6 @@ from matplotlib.dates import mx2num, date2num, DateFormatter
 from matplotlib.backends.backend_agg import FigureCanvasAgg  
 
 from math import ceil
-from six.moves import range
 
 #import pytz
 #tz=pytz.timezone('US/Eastern') # Why, oh, why, is it using my local time zone?

--- a/lmatools/vis/small_multiples.py
+++ b/lmatools/vis/small_multiples.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import matplotlib 
-from six.moves import range
-matplotlib.rc('xtick', labelsize=6) 
+matplotlib.rc('xtick', labelsize=6)
 matplotlib.rc('ytick', labelsize=6) 
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='lmatools',
     version='0.6a',
@@ -8,9 +8,10 @@ setup(name='lmatools',
     author_email='eric.bruning@gmail.com',
     url='https://github.com/deeplycloudy/lmatools/',
     # package_dir={'lmatools': ''}, # wouldn't be necessary if we reorganized to traditional package layout with lmatools at the same directory level as the setup.py script.
-    packages=['lmatools', 'lmatools.flashsort', 'lmatools.flashsort.autosort', 
-              'lmatools.io', 'lmatools.lasso', 'lmatools.grid', 
+    packages=['lmatools', 'lmatools.flashsort', 'lmatools.flashsort.autosort',
+              'lmatools.io', 'lmatools.lasso', 'lmatools.grid',
               'lmatools.stream', 'lmatools.vis', 'lmatools.test',
               'lmatools.sampledata',],
     package_data={'lmatools.sampledata':['ASCII_solutions/*.dat.gz']},
+    install_requires=['numpy','scipy','pyproj'],
     )


### PR DESCRIPTION
As discussed in https://github.com/deeplycloudy/glmtools/pull/56, lmatools depends on six but doesn't list it as a dependency. The package could either list this as a dependency in setup.py **or** it could drop `six` as a dependency which means python 2 support is also dropped. This PR does the latter.

This was pretty easy to accomplish and in general includes three types of changes:

1. Remove six imports for `range`, `map`, and `zip` which were being used for getting an iterator instead of a list like python 2's version of these functions.
2. Importing `iteritems` to get the iterator version of `my_dict.items()` by doing `iteritems(my_dict)`. In python 3 the first form is an iterator.
3. An import of the `next` function which only exists in python 2 as a `my_iter.next()` method, if I remember correctly. This is the only change that should make the code non-py2 compatibie.