### PR TITLE
fix with new version of scipy, vertices became simplices

### DIFF
--- a/lmatools/flashsort/flash_stats.py
+++ b/lmatools/flashsort/flash_stats.py
@@ -76,7 +76,7 @@ def hull_volume(xyz):
     assert xyz.shape[1] == 3
         
     tri = Delaunay(xyz[:,0:3])
-    vertices = tri.points[tri.vertices]
+    vertices = tri.points[tri.simplices]
     
     # This is the volume formula in 
     # https://github.com/scipy/scipy/blob/master/scipy/spatial/tests/test_qhull.py#L106


### PR DESCRIPTION
I had to get this working to test chargepol using pyxlma data. In an ironic twist, attempting to replace lmatools with pyxlma provided a reason to keep lmatools limping along...