### PR TITLE
Create pyproject.toml to support future versions of pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+# pyproject.toml
+[build-system]
+# XXX: If your project needs other packages to build properly, add them to this list.
+requires = ["setuptools >= 42.0.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Pip is loosing the ability to build packages without a pyproject.toml in the future: https://github.com/pypa/pip/issues/6334

This pull request adds a minimal pyproject.toml as specified in the above link 